### PR TITLE
Upgrade hyper to 0.10, openssl to 0.9

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,12 +18,13 @@ Works only for S3. Other AWS Storage features are coming soon!
 """
 
 [dependencies]
-lsio = "0.1"
+lsio = "0.1, >=0.1.16"
 chrono = "0.2"
 httparse = "1"
-hyper = "0.9"
+hyper = "0.10"
+hyper-openssl = "0.2"
 log = "0.3.6"
-openssl = "0.7"
+openssl = "0.9"
 regex = "0.1"
 rustc-serialize = "0.3"
 # Credentials use serde

--- a/src/http/client/error.rs
+++ b/src/http/client/error.rs
@@ -34,7 +34,7 @@ use std::fmt;
 use std::result;
 
 use hyper;
-use openssl::ssl;
+use openssl;
 use url;
 
 #[derive(Debug)]
@@ -43,7 +43,7 @@ pub enum Error {
     /// Occurs when an improper http or https proxy value is given.
     InvalidProxyValue(String),
     IO(io::Error),
-    SslError(ssl::error::SslError),
+    SslError(openssl::error::Error),
     /// When an error occurs attempting to parse a string into a URL.
     UrlParseError(url::ParseError),
 }
@@ -87,8 +87,8 @@ impl From<io::Error> for Error {
     }
 }
 
-impl From<ssl::error::SslError> for Error {
-    fn from(err: ssl::error::SslError) -> Error {
+impl From<openssl::error::Error> for Error {
+    fn from(err: openssl::error::Error) -> Error {
         Error::SslError(err)
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,6 +35,7 @@ extern crate httparse;
 
 #[macro_use]
 extern crate hyper;
+extern crate hyper_openssl;
 
 // Only aws crate is documented, not the dependents.
 pub mod aws;


### PR DESCRIPTION
I was able to compile s3lsio with these changes and uploading to s3 worked correctly.

The new `openssl` API methods returns `Result<>` values. This pull request does not handle those Results values but calls `.unwrap()`'s. Proper error handling there would require changes to existing methods/API of `aws-sdk-rust`, I'm not sure what's the best way to implement that at the moment.

Also I'm not sure if the proxy code I updated is correct, because I don't have a way to test it currently.

