### PR TITLE
ensure proper encoding of url and signed values

### DIFF
--- a/examples/s3.rs
+++ b/examples/s3.rs
@@ -193,7 +193,7 @@ fn main() {
     // This is the first thing that needs to be done. Initiate the request and get the uploadid.
     // Generate a test file of 8MB in size...
     let test_abort: bool = false;
-    let file_size: u16 = 8;
+    let file_size: u16 = 8; // MiB
     // NOTE: .gitignore has this file name as an ignore. If you change this file name then change .gitignore if you also want to issue a PR.
     let file_name: &str = "test.multipart.upload.file";
     // NOTE: The temp file will be removed after the test. If you want to keep the file then set this to false.
@@ -211,7 +211,9 @@ fn main() {
             create_multipart_upload_output = Some(output);
             // Only for *nix based systems - the following command
             if file_create {
-                let result = run_cli(format!("dd if=/dev/zero ibs={}m count=1 of={}", file_size, file_name.to_string()));
+                let cmd = format!("dd if=/dev/zero ibs={}M count=1 of={}", file_size * 1048576, file_name.to_string());
+                let result = run_cli(cmd.clone()).unwrap();
+                assert!(result.status.success(), "command exited with an error: {:?}", cmd)
             }
         },
         Err(e) => println_color!(term::color::RED, "{:#?}", e),

--- a/src/aws/common/encode.rs
+++ b/src/aws/common/encode.rs
@@ -1,0 +1,75 @@
+use url::percent_encoding::{EncodeSet, utf8_percent_encode};
+
+#[derive(Clone, Copy)]
+#[allow(non_camel_case_types)]
+struct URI_ENCODE_SET;
+
+impl EncodeSet for URI_ENCODE_SET {
+    fn contains(&self, byte: u8) -> bool {
+        match byte {
+            b'A'...b'Z' | b'a'...b'z' | b'0'...b'9' | b'-' | b'.' | b'_' | b'~' => false,
+            _ => true,
+        }
+    }
+}
+
+#[derive(Clone, Copy)]
+#[allow(non_camel_case_types)]
+struct URI_ENCODE_SET_WITHOUT_SLASH;
+
+impl EncodeSet for URI_ENCODE_SET_WITHOUT_SLASH {
+    fn contains(&self, byte: u8) -> bool {
+        match byte {
+            b'A'...b'Z' | b'a'...b'z' | b'0'...b'9' | b'-' | b'.' | b'_' | b'~' | b'/' => false,
+            _ => true,
+        }
+    }
+}
+
+/// Percent-encoding according to S3 specification
+///
+/// # From the Specification
+///
+/// * URI encode every byte except the unreserved characters: 'A'-'Z', 'a'-'z', '0'-'9', '-', '.',
+///   '_', and '~'.
+/// * The space character is a reserved character and must be encoded as "%20" (and not as "+").
+/// * Each URI encoded byte is formed by a '%' and the two-digit hexadecimal value of the byte.
+/// * Letters in the hexadecimal value must be uppercase, for example "%1A".
+///
+/// source: [https://docs.aws.amazon.com/AmazonS3/latest/API/sig-v4-header-based-auth.html]()
+#[inline]
+pub fn encode_uri(uri: &str) -> String {
+    utf8_percent_encode(uri, URI_ENCODE_SET).collect()
+}
+
+/// Percent-encoding for bucket keys according to S3 specification
+///
+/// This is identical to `encode_uri` with the exception that '/' is not encoded.
+///
+/// # From the Specification
+///
+/// * Encode the forward slash character, '/', everywhere except in the object key name. For
+/// example, if the object key name is photos/Jan/sample.jpg, the forward slash in the key name
+/// is not encoded.
+/// * all the rules from `encode_uri`
+///
+/// source: [https://docs.aws.amazon.com/AmazonS3/latest/API/sig-v4-header-based-auth.html]()
+#[inline]
+pub fn encode_uri_object_key(uri: &str) -> String {
+    utf8_percent_encode(uri, URI_ENCODE_SET_WITHOUT_SLASH).collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_encode_uri() {
+        assert_eq!("a%20%2Bbb%2Fc", encode_uri("a +bb/c"));
+    }
+
+    #[test]
+    fn test_encode_uri_object_key() {
+        assert_eq!("a%20%2Bbb/c", encode_uri_object_key("a +bb/c"));
+    }
+}

--- a/src/aws/common/mod.rs
+++ b/src/aws/common/mod.rs
@@ -20,6 +20,8 @@
 pub mod common;
 /// `credentials` contains the type, struct, enum and impls that are credentials related.
 pub mod credentials;
+/// Functions needed for percent-encoding
+pub mod encode;
 /// `region` contains the type, struct, enum and impls for Region related functions.
 pub mod region;
 /// `xmlutil` contains the type, struct, enum and impls that are common XML parsing and writing.

--- a/src/aws/common/request.rs
+++ b/src/aws/common/request.rs
@@ -114,7 +114,7 @@ impl DispatchSignedRequest for Client {
                                     request.endpoint_scheme(),
                                     request.hostname(),
                                     port_str,
-                                    request.path());
+                                    request.canonical_uri());
         if !request.canonical_query_string().is_empty() {
             let uri = final_uri.clone();
             final_uri = final_uri + &format!("{}{}", if uri.contains("?") {""} else {"?"}, request.canonical_query_string());

--- a/src/aws/common/request.rs
+++ b/src/aws/common/request.rs
@@ -114,7 +114,7 @@ impl DispatchSignedRequest for Client {
                                     request.endpoint_scheme(),
                                     request.hostname(),
                                     port_str,
-                                    request.canonical_uri());
+                                    request.path());
         if !request.canonical_query_string().is_empty() {
             let uri = final_uri.clone();
             final_uri = final_uri + &format!("{}{}", if uri.contains("?") {""} else {"?"}, request.canonical_query_string());

--- a/src/aws/common/signature.rs
+++ b/src/aws/common/signature.rs
@@ -41,9 +41,9 @@ use rustc_serialize::hex::ToHex;
 use rustc_serialize::base64::{STANDARD, ToBase64};
 use time::Tm;
 use time::now_utc;
-use url::percent_encoding::{DEFAULT_ENCODE_SET, QUERY_ENCODE_SET, utf8_percent_encode};
 
 use aws::common::credentials::AwsCredentials;
+use aws::common::encode::{encode_uri, encode_uri_object_key};
 use aws::common::params::Params;
 use aws::common::region::Region;
 use aws::s3::endpoint::Signature;
@@ -535,7 +535,7 @@ fn canonical_values(values: &[Vec<u8>]) -> String {
 fn canonical_uri(path: &str) -> String {
     match path {
         "" => "/".to_string(),
-        _ => encode_uri(path),
+        _ => encode_uri_object_key(path),
     }
 }
 
@@ -580,27 +580,17 @@ fn build_canonical_query_string(params: &Params) -> String {
         if !output.is_empty() {
             output.push_str("&");
         }
-        output.push_str(&byte_serialize(item.0));
+        output.push_str(&encode_uri(item.0));
         output.push_str("=");
-        output.push_str(&byte_serialize(item.1));
+        output.push_str(&encode_uri(item.1));
     }
 
     output
 }
 
 #[inline]
-fn encode_uri(uri: &str) -> String {
-    utf8_percent_encode(uri, QUERY_ENCODE_SET).collect::<String>()
-}
-
-#[inline]
-fn byte_serialize(input: &str) -> String {
-    utf8_percent_encode(input, DEFAULT_ENCODE_SET).collect::<String>()
-}
-
 fn to_hexdigest_from_string(val: &str) -> String {
-    let h = hash(MessageDigest::sha256(), val.as_bytes()).unwrap();
-    h.to_hex().to_string()
+    to_hexdigest_from_bytes(&val.as_bytes())
 }
 
 fn to_hexdigest_from_bytes(val: &[u8]) -> String {
@@ -645,12 +635,8 @@ fn canonical_headers_v2(headers: &BTreeMap<String, Vec<Vec<u8>>>) -> String {
         if skipped_headers(item.0) {
             continue;
         } else {
-            match item.0.to_ascii_lowercase().find("x-amz-") {
-                None => {},
-                _ => canonical.push_str(format!("{}:{}\n",
-                                                item.0.to_ascii_lowercase(),
-                                                canonical_values(item.1))
-                    .as_ref()),
+            if item.0.contains("x-amz-") {
+                canonical.push_str(format!("{}:{}\n", item.0, canonical_values(item.1)).as_ref());
             };
         }
     }
@@ -661,19 +647,19 @@ fn canonical_headers_v2(headers: &BTreeMap<String, Vec<Vec<u8>>>) -> String {
 // NOTE: If bucket contains '.' it is already formatted in path so just encode it.
 fn canonical_resources_v2(bucket: &str, path: &str, is_bucket_virtual: bool) -> String {
     if bucket.to_string().contains(".") || !is_bucket_virtual {
-        encode_uri(path)
+        encode_uri_object_key(path)
     } else {
         match bucket {
             "" => {
                 match path {
                     "" => "/".to_string(),
-                    _ => encode_uri(path),  // This assumes / as leading char
+                    _ => encode_uri_object_key(path),  // This assumes / as leading char
                 }
             },
             _ => {
                 match path {
                     "" => format!("/{}/", bucket),
-                    _ => encode_uri(&format!("/{}{}", bucket, path)),  // This assumes path with leading / char
+                    _ => encode_uri_object_key(&format!("/{}{}", bucket, path)),  // This assumes path with leading / char
                 }
             },
         }


### PR DESCRIPTION
* Use percent encoding as [specified by Amazon](https://docs.aws.amazon.com/AmazonS3/latest/API/sig-v4-header-based-auth.html).
* Use canonical path in URL for requests. Using '+' never worked on
  Amazon and [stopped working for Ceph](https://github.com/ceph/ceph/commit/20e5ff023ebad89c386a520d07613547d4836399). Encoding the whole URL
  should avoid similar issues in the future
* Don't `String::to_ascii_lowercase` when getting canonical headers.
  Keys are already lower cased when inserted.
