### PR TITLE
Fix example code to use buffered get_object result data

### DIFF
--- a/examples/s3.rs
+++ b/examples/s3.rs
@@ -171,7 +171,7 @@ fn main() {
     get_object.key = "mytest.txt".to_string();
 
     match client.get_object(&get_object, None) {
-        Ok(output) => println_color!(term::color::GREEN, "\n\n{:#?}\n\n", str::from_utf8(&output.body).unwrap()),
+        Ok(output) => println_color!(term::color::GREEN, "\n\n{:#?}\n\n", str::from_utf8(&output.body_buffer).unwrap()),
         Err(e) => println_color!(term::color::RED, "{:#?}", e),
     }
 


### PR DESCRIPTION
Apparently large data results of a `get_object` call are buffered and the `.body`
property is empty in that case. `.body_buffer` contains the full response data.

This has bit me in my application where integration tests using small test data succeeded but production data (large image blobs) didn't work and 0 bytes were retrieved.

cc @hanscj1