### PR TITLE
Fix the README example code

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ extern crate hyper;
 
 use aws_sdk_rust::aws::common::credentials::DefaultCredentialsProvider;
 use aws_sdk_rust::aws::common::region::Region;
-use aws_sdk_rust::aws::s3::endpoint::Endpoint;
+use aws_sdk_rust::aws::s3::endpoint::{Endpoint, Signature};
 use aws_sdk_rust::aws::s3::s3client::S3Client;
 
 fn main() {
@@ -94,7 +94,7 @@ fn main() {
     let provider = DefaultCredentialsProvider::new(None).unwrap();
 
     // V4 is the default signature for AWS. However, other systems also use V2.
-    let endpoint = Endpoint::new(Region::UsEast1, Signature::V4, None, None, None);
+    let endpoint = Endpoint::new(Region::UsEast1, Signature::V4, None, None, None, None);
     let client = S3Client::new(provider, endpoint);
 
     match client.list_buckets() {


### PR DESCRIPTION
* `Signature` import missing
* 6th parameter of endpoint constructor missing

cc @hanscj1